### PR TITLE
Update snap

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -7,3 +7,6 @@ includes:
   - interface:pgsql
   - interface:nrpe-external-master
 repo: https://github.com/CanonicalLtd/basic-auth-service-charm
+options:
+    basic:
+        use_venv: true


### PR DESCRIPTION
This branch manually updates the local snap (something that is no automatic through refresh, given the filename change). Additionally, this ensures that the charm runs in a venv to prevent version problems with older subordinate charms.