### PR TITLE
Ensure that snap core is installed

### DIFF
--- a/reactive/basic_auth.py
+++ b/reactive/basic_auth.py
@@ -45,6 +45,9 @@ def charm_state(state):
 
 
 def install_local_snap():
+    # Ensure the core snap is installed first to work around
+    # https://bugs.launchpad.net/snappy/+bug/1761253.
+    snap.install('core')
     charm_dir = os.environ['JUJU_CHARM_DIR']
     snap_path = os.path.join(charm_dir, SNAP_FILE_NAME)
     snap_file = glob.glob(snap_path)[0]


### PR DESCRIPTION
This ensures that snap core is installed to prevent issues such as the inability to create sockets. See https://bugs.launchpad.net/snappy/+bug/1761253 for details.